### PR TITLE
Remove code that forces Experience bar bubbles

### DIFF
--- a/ElvUI/Core/Core.lua
+++ b/ElvUI/Core/Core.lua
@@ -1240,10 +1240,6 @@ function E:DBConversions()
 			E.db.movers.ElvTooltipMover = E.db.movers.TooltipMover
 			E.db.movers.TooltipMover = nil
 		end
-
-		if E.db.databars.experience.questXP and E.db.databars.experience.questXP.showBubbles then
-			E.db.databars.experience.showBubbles = true
-		end
 	end
 end
 


### PR DESCRIPTION
The option to toggle bubbles on QuestXP was added in 788ec7a and removed in the next commit 037cb90.
This means that the option may be enabled and tattooed in people's personal config and unable to be disabled.